### PR TITLE
[ch2238] missing metrics in swarm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ ADD conf/graphite.conf /etc/nginx/sites-enabled/graphite
 ADD conf/supervisord.conf /etc/supervisord.conf
 
 # Graphite/statsd/carbon config files
+ADD conf/carbon.sh /carbon.sh
 ADD conf/statsd-config.js /opt/statsd/config.js
 ADD conf/aggregation-rules.conf /opt/graphite/conf/aggragation-rules.conf
 ADD conf/blacklist.conf /opt/graphite/conf/blacklist.conf
@@ -56,6 +57,7 @@ RUN mv /opt/graphite/conf/graphite.wsgi.example /opt/graphite/conf/wsgi.py
 RUN mkdir -p /var/log/supervisord /var/log/nginx /var/log/graphite /var/log/carbon /var/log/uwsgi /opt/graphite/storage /var/run/supervisord /var/run/nginx /var/run/uwsgi /crypto /var/lib/nginx /var/tmp
 RUN cd /var/log/graphite/ && touch info.log exception.log
 RUN chmod -R a+rwx /var/log/supervisord /var/log/nginx /var/log/graphite /var/log/carbon /var/log/uwsgi /opt/graphite/storage /var/run/supervisord /var/run/nginx /var/run/uwsgi /crypto /var/lib/nginx /var/tmp
+RUN chmod a+x /carbon.sh
 
 # Configure django DB
 RUN PYTHONPATH=/opt/graphite/webapp python /usr/bin/django-admin.py migrate --settings=graphite.settings --run-syncdb

--- a/conf/carbon.sh
+++ b/conf/carbon.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# The intention of this shell wrapper is to manage the PID file created by carbon-cache.
+# If the file is left over, carbon-cache will refuse to start.
+# The --nodaemon option allows the process to be managed by supervisord.
+# The --pidfile overrides the default location which is on a mounted volume, which survives container restarts.
+
+rm -f /tmp/carbon.pid
+/opt/graphite/bin/carbon-cache.py start --nodaemon --logdir=/var/log/carbon --pidfile=/tmp/carbon.pid

--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -5,9 +5,9 @@ nodaemon = true
 command = node /opt/statsd/stats.js /opt/statsd/config.js
 
 [program:carbon-cache]
-command     = /opt/graphite/bin/carbon-cache.py start --logdir=/var/log/carbon
+command     = /carbon.sh
 startsecs	= 0
-autorestart	= false
+autorestart	= true
 
 [program:uwsgi]
 command     = /usr/sbin/uwsgi --ini /etc/uwsgi/apps-enabled/conf/graphite.ini --pidfile /var/run/uwsgi/uwsgi.pid


### PR DESCRIPTION
 - make supervisord manage carbon process and clean up PID file so it can restart when needed.