### PR TITLE
remove tls v1 and v1.1 [ch16238]

### DIFF
--- a/conf/graphite.conf
+++ b/conf/graphite.conf
@@ -5,7 +5,7 @@ upstream graphite {
 server {
     listen 2443 ssl;
 
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_protocols TLSv1.2;
     ssl_certificate /crypto/ssl.crt;
     ssl_certificate_key /crypto/ssl.key;
 

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -16,7 +16,7 @@ http {
 	include /etc/nginx/mime.types;
 	default_type application/octet-stream;
 
-	ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # Dropping SSLv3, ref: POODLE
+	ssl_protocols TLSv1.2;
 	ssl_prefer_server_ciphers on;
 
 	access_log            /var/log/nginx/access.log;


### PR DESCRIPTION
v1.0 has to be removed for PCI compliance by June 2018
v1.1 is barely used and will be deprecated March 2020