### PR TITLE
Resolve CVEs

### DIFF
--- a/Dockerfile.hack
+++ b/Dockerfile.hack
@@ -3,6 +3,7 @@ FROM registry.replicated.com/library/statsd-graphite:1.1.8-20211119
 # Install dependencies
 RUN apt-get update && apt-get upgrade -y \
   && apt-get purge dpkg-dev -y \
+  && apt-get purge git -y \
   && apt-get clean \
   && apt-get autoremove -y \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Known CVEs at the time of this PR

```
NAME                  INSTALLED                FIXED-IN                 VULNERABILITY   SEVERITY 
git                   1:2.20.1-2+deb10u3       1:2.20.1-2+deb10u4       CVE-2021-40330  High      
git                   1:2.20.1-2+deb10u3       1:2.20.1-2+deb10u4       CVE-2021-21300  High      
libc-bin              2.28-10+deb10u1          2.28-10+deb10u2          CVE-2016-10228  Medium    
libc-bin              2.28-10+deb10u1          2.28-10+deb10u2          CVE-2021-33574  Critical  
libc-bin              2.28-10+deb10u1          2.28-10+deb10u2          CVE-2021-3999   High      
libc-bin              2.28-10+deb10u1          2.28-10+deb10u2          CVE-2020-10029  Medium    
libc-bin              2.28-10+deb10u1          2.28-10+deb10u2          CVE-2021-27645  Low       
libc-bin              2.28-10+deb10u1          2.28-10+deb10u2          CVE-2021-3326   High      
libc-bin              2.28-10+deb10u1          2.28-10+deb10u2          CVE-2019-25013  Medium    
libc-bin              2.28-10+deb10u1          2.28-10+deb10u2          CVE-2020-27618  Medium    
libc-bin              2.28-10+deb10u1          2.28-10+deb10u2          CVE-2020-1752   High      
libc-bin              2.28-10+deb10u1          2.28-10+deb10u2          CVE-2020-6096   High      
libc-bin              2.28-10+deb10u1          2.28-10+deb10u2          CVE-2021-35942  Critical  
libc-bin              2.28-10+deb10u1          2.28-10+deb10u2          CVE-2022-23219  Critical  
libc-bin              2.28-10+deb10u1          2.28-10+deb10u2          CVE-2019-19126  Low       
libc-bin              2.28-10+deb10u1          2.28-10+deb10u2          CVE-2022-23218  Critical  
libc-dev-bin          2.28-10+deb10u1          2.28-10+deb10u2          CVE-2020-1752   High      
libc-dev-bin          2.28-10+deb10u1          2.28-10+deb10u2          CVE-2022-23219  Critical  
libc-dev-bin          2.28-10+deb10u1          2.28-10+deb10u2          CVE-2016-10228  Medium    
libc-dev-bin          2.28-10+deb10u1          2.28-10+deb10u2          CVE-2019-25013  Medium    
libc-dev-bin          2.28-10+deb10u1          2.28-10+deb10u2          CVE-2022-23218  Critical  
libc-dev-bin          2.28-10+deb10u1          2.28-10+deb10u2          CVE-2021-3326   High      
libc-dev-bin          2.28-10+deb10u1          2.28-10+deb10u2          CVE-2021-35942  Critical  
libc-dev-bin          2.28-10+deb10u1          2.28-10+deb10u2          CVE-2021-33574  Critical  
libc-dev-bin          2.28-10+deb10u1          2.28-10+deb10u2          CVE-2021-3999   High      
libc-dev-bin          2.28-10+deb10u1          2.28-10+deb10u2          CVE-2019-19126  Low       
libc-dev-bin          2.28-10+deb10u1          2.28-10+deb10u2          CVE-2020-27618  Medium    
libc-dev-bin          2.28-10+deb10u1          2.28-10+deb10u2          CVE-2021-27645  Low       
libc-dev-bin          2.28-10+deb10u1          2.28-10+deb10u2          CVE-2020-10029  Medium    
libc-dev-bin          2.28-10+deb10u1          2.28-10+deb10u2          CVE-2020-6096   High      
libc6                 2.28-10+deb10u1          2.28-10+deb10u2          CVE-2016-10228  Medium    
libc6                 2.28-10+deb10u1          2.28-10+deb10u2          CVE-2021-27645  Low       
libc6                 2.28-10+deb10u1          2.28-10+deb10u2          CVE-2021-35942  Critical  
libc6                 2.28-10+deb10u1          2.28-10+deb10u2          CVE-2020-1752   High      
libc6                 2.28-10+deb10u1          2.28-10+deb10u2          CVE-2021-3326   High      
libc6                 2.28-10+deb10u1          2.28-10+deb10u2          CVE-2020-10029  Medium    
libc6                 2.28-10+deb10u1          2.28-10+deb10u2          CVE-2022-23218  Critical  
libc6                 2.28-10+deb10u1          2.28-10+deb10u2          CVE-2022-23219  Critical  
libc6                 2.28-10+deb10u1          2.28-10+deb10u2          CVE-2021-33574  Critical  
libc6                 2.28-10+deb10u1          2.28-10+deb10u2          CVE-2019-19126  Low       
libc6                 2.28-10+deb10u1          2.28-10+deb10u2          CVE-2020-27618  Medium    
libc6                 2.28-10+deb10u1          2.28-10+deb10u2          CVE-2020-6096   High      
libc6                 2.28-10+deb10u1          2.28-10+deb10u2          CVE-2021-3999   High      
libc6                 2.28-10+deb10u1          2.28-10+deb10u2          CVE-2019-25013  Medium    
libc6-dev             2.28-10+deb10u1          2.28-10+deb10u2          CVE-2020-6096   High      
libc6-dev             2.28-10+deb10u1          2.28-10+deb10u2          CVE-2020-1752   High      
libc6-dev             2.28-10+deb10u1          2.28-10+deb10u2          CVE-2020-10029  Medium    
libc6-dev             2.28-10+deb10u1          2.28-10+deb10u2          CVE-2021-35942  Critical  
libc6-dev             2.28-10+deb10u1          2.28-10+deb10u2          CVE-2021-27645  Low       
libc6-dev             2.28-10+deb10u1          2.28-10+deb10u2          CVE-2021-3999   High      
libc6-dev             2.28-10+deb10u1          2.28-10+deb10u2          CVE-2022-23218  Critical  
libc6-dev             2.28-10+deb10u1          2.28-10+deb10u2          CVE-2020-27618  Medium    
libc6-dev             2.28-10+deb10u1          2.28-10+deb10u2          CVE-2019-19126  Low       
libc6-dev             2.28-10+deb10u1          2.28-10+deb10u2          CVE-2021-3326   High      
libc6-dev             2.28-10+deb10u1          2.28-10+deb10u2          CVE-2019-25013  Medium    
libc6-dev             2.28-10+deb10u1          2.28-10+deb10u2          CVE-2022-23219  Critical  
libc6-dev             2.28-10+deb10u1          2.28-10+deb10u2          CVE-2021-33574  Critical  
libc6-dev             2.28-10+deb10u1          2.28-10+deb10u2          CVE-2016-10228  Medium    
libexpat1             2.2.6-2+deb10u4          2.2.6-2+deb10u6          CVE-2022-43680  High      
libexpat1             2.2.6-2+deb10u4          2.2.6-2+deb10u5          CVE-2022-40674  Critical  
libexpat1-dev         2.2.6-2+deb10u4          2.2.6-2+deb10u6          CVE-2022-43680  High      
libexpat1-dev         2.2.6-2+deb10u4          2.2.6-2+deb10u5          CVE-2022-40674  Critical  
libfreetype6          2.9.1-3+deb10u2          2.9.1-3+deb10u3          CVE-2022-27406  High      
libfreetype6          2.9.1-3+deb10u2          2.9.1-3+deb10u3          CVE-2022-27404  Critical  
libfreetype6          2.9.1-3+deb10u2          2.9.1-3+deb10u3          CVE-2022-27405  High      
libgssapi-krb5-2      1.17-3+deb10u3           1.17-3+deb10u5           CVE-2022-42898  Unknown   
libk5crypto3          1.17-3+deb10u3           1.17-3+deb10u5           CVE-2022-42898  Unknown   
libkrb5-3             1.17-3+deb10u3           1.17-3+deb10u5           CVE-2022-42898  Unknown   
libkrb5support0       1.17-3+deb10u3           1.17-3+deb10u5           CVE-2022-42898  Unknown   
libksba8              1.3.5-2                  1.3.5-2+deb10u1          CVE-2022-3515   Unknown   
libncursesw6          6.1+20181013-2+deb10u2   6.1+20181013-2+deb10u3   CVE-2022-29458  High      
libpixman-1-0         0.36.0-1                 0.36.0-1+deb10u1         CVE-2022-44638  High      
libpython3.7          3.7.3-2+deb10u3          3.7.3-2+deb10u4          CVE-2022-37454  Critical  
libpython3.7-dev      3.7.3-2+deb10u3          3.7.3-2+deb10u4          CVE-2022-37454  Critical  
libpython3.7-minimal  3.7.3-2+deb10u3          3.7.3-2+deb10u4          CVE-2022-37454  Critical  
libpython3.7-stdlib   3.7.3-2+deb10u3          3.7.3-2+deb10u4          CVE-2022-37454  Critical  
libsqlite3-0          3.27.2-3+deb10u1         3.27.2-3+deb10u2         CVE-2020-35525  High      
libsqlite3-0          3.27.2-3+deb10u1         3.27.2-3+deb10u2         CVE-2020-35527  Critical  
libtinfo6             6.1+20181013-2+deb10u2   6.1+20181013-2+deb10u3   CVE-2022-29458  High      
linux-libc-dev        4.19.249-2               4.19.260-1               CVE-2022-20422  High      
linux-libc-dev        4.19.249-2               4.19.260-1               CVE-2022-33744  Medium    
linux-libc-dev        4.19.249-2               4.19.260-1               CVE-2022-2318   Medium    
linux-libc-dev        4.19.249-2               4.19.260-1               CVE-2022-39188  Medium    
linux-libc-dev        4.19.249-2               4.19.260-1               CVE-2021-33656  Medium    
linux-libc-dev        4.19.249-2               4.19.260-1               CVE-2022-1679   High      
linux-libc-dev        4.19.249-2               4.19.260-1               CVE-2022-26373  Medium    
linux-libc-dev        4.19.249-2               4.19.260-1               CVE-2022-40307  Medium    
linux-libc-dev        4.19.249-2               4.19.260-1               CVE-2022-26365  High      
linux-libc-dev        4.19.249-2               4.19.260-1               CVE-2022-20566  Unknown   
linux-libc-dev        4.19.249-2               4.19.260-1               CVE-2022-3635   High      
linux-libc-dev        4.19.249-2               4.19.260-1               CVE-2022-3629   Low       
linux-libc-dev        4.19.249-2               4.19.260-1               CVE-2022-2153   Medium    
linux-libc-dev        4.19.249-2               4.19.260-1               CVE-2022-33742  High      
linux-libc-dev        4.19.249-2               4.19.260-1               CVE-2022-39842  Medium    
linux-libc-dev        4.19.249-2               4.19.260-1               CVE-2022-4095   Unknown   
linux-libc-dev        4.19.249-2               4.19.260-1               CVE-2022-42703  Medium    
linux-libc-dev        4.19.249-2               4.19.260-1               CVE-2022-2586   Unknown   
linux-libc-dev        4.19.249-2               4.19.260-1               CVE-2022-3586   Medium    
linux-libc-dev        4.19.249-2               4.19.260-1               CVE-2022-20421  High      
linux-libc-dev        4.19.249-2               4.19.260-1               CVE-2021-33655  Medium    
linux-libc-dev        4.19.249-2               4.19.260-1               CVE-2021-4159   Medium    
linux-libc-dev        4.19.249-2               4.19.260-1               CVE-2022-36946  High      
linux-libc-dev        4.19.249-2               4.19.260-1               CVE-2022-33740  High      
linux-libc-dev        4.19.249-2               4.19.260-1               CVE-2022-1462   Medium    
linux-libc-dev        4.19.249-2               4.19.260-1               CVE-2022-2588   Unknown   
linux-libc-dev        4.19.249-2               4.19.260-1               CVE-2022-33741  High      
linux-libc-dev        4.19.249-2               4.19.260-1               CVE-2022-36879  Medium    
linux-libc-dev        4.19.249-2               4.19.260-1               CVE-2022-2663   Medium    
linux-libc-dev        4.19.249-2               4.19.260-1               CVE-2022-3028   High      
ncurses-base          6.1+20181013-2+deb10u2   6.1+20181013-2+deb10u3   CVE-2022-29458  High      
ncurses-bin           6.1+20181013-2+deb10u2   6.1+20181013-2+deb10u3   CVE-2022-29458  High      
python3.7             3.7.3-2+deb10u3          3.7.3-2+deb10u4          CVE-2022-37454  Critical  
python3.7-dev         3.7.3-2+deb10u3          3.7.3-2+deb10u4          CVE-2022-37454  Critical  
python3.7-minimal     3.7.3-2+deb10u3          3.7.3-2+deb10u4          CVE-2022-37454  Critical  
zlib1g                1:1.2.11.dfsg-1+deb10u1  1:1.2.11.dfsg-1+deb10u2  CVE-2022-37434  Critical  
1 error occurred:
	* discovered vulnerabilities at or above the severity threshold

```