### PR TITLE
update Dockerfile.hack to add new volume mount

### DIFF
--- a/Dockerfile.hack
+++ b/Dockerfile.hack
@@ -7,3 +7,5 @@ RUN apt-get update && apt-get upgrade -y \
   && apt-get clean \
   && apt-get autoremove -y \
   && rm -rf /var/lib/apt/lists/*
+
+VOLUME /tmp


### PR DESCRIPTION
So 'Dockerfile' hasn't been used for two years, who knew?