### PR TITLE
fix: readonly root fs twisted plugin cache errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,7 @@ EXPOSE 2443
 EXPOSE 8125/udp
 
 # Enable users of this container to mount their volumes (optional)
-VOLUME ["/opt/graphite/conf", "/opt/graphite/storage", "/opt/graphite/webapp/graphite/functions/custom", "/etc/nginx", "/opt/statsd/config", "/etc/logrotate.d", "/var/log", "/var/lib/redis", "/crypto", "/tmp", "/var/run/uwsgi", "/var/run/nginx"]
+VOLUME ["/opt/graphite/conf", "/opt/graphite/storage", "/opt/graphite/webapp/graphite/functions/custom", "/etc/nginx", "/opt/statsd/config", "/etc/logrotate.d", "/var/log", "/var/lib/redis", "/crypto", "/tmp", "/var/run/uwsgi", "/var/run/nginx", "/opt/graphite/lib/twisted/plugins", "/opt/graphite/lib/python3.7/site-packages/twisted/plugins"]
 
 # Start supervisor by default
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisord.conf", "-l", "/var/log/supervisor/supervisord.log", "-j", "/var/run/supervisord/supervisord.pid"]


### PR DESCRIPTION
```
7 Jun 19:50:39 - [12] reading config file: /opt/statsd/config.js
7 Jun 19:50:39 - server is up INFO
Starting carbon-cache (instance a)
07/06/2023 19:50:39 :: [console] Unable to write to plugin cache /opt/graphite/lib/python3.7/site-packages/twisted/plugins/dropin.cache: error number 30
07/06/2023 19:50:39 :: [console] Unable to write to plugin cache /opt/graphite/lib/twisted/plugins/dropin.cache: error number 30
07/06/2023 19:50:39 :: [console] Unable to write to plugin cache /opt/graphite/lib/python3.7/site-packages/twisted/plugins/dropin.cache: error number 30
07/06/2023 19:50:39 :: [console] Unable to write to plugin cache /opt/graphite/lib/twisted/plugins/dropin.cache: error number 30
07/06/2023 19:50:39 :: [console] Using sorted write strategy for cache
07/06/2023 19:50:39 :: [console] Enabling Whisper fallocate support
```

```
ethan@ethanm-repl-airgap-3:~$ sudo docker exec -it replicated-statsd bash
I have no name!@ee77b688b2fa:/$ ls /opt/graphite/lib/twisted/plugins/
__pycache__			   carbon_aggregator_plugin.py	carbon_relay_plugin.py
carbon_aggregator_cache_plugin.py  carbon_cache_plugin.py
I have no name!@ee77b688b2fa:/$ touch /opt/graphite/lib/twisted/plugins/dropin.cache
touch: cannot touch '/opt/graphite/lib/twisted/plugins/dropin.cache': Read-only file system
```