### PR TITLE
Dockerfile: remove NPM cacache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends build-essential
   && apt-get remove -y build-essential python3-pip python3-setuptools libffi-dev git \
   && apt-get clean \
   && apt-get autoremove -y \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* \
+  && rm -rf /root/.npm/_cacache
 
 # Configure nginx site
 RUN rm -rf /etc/nginx/sites-enabled/*


### PR DESCRIPTION
this shrinks the image from 596MB to 582MB, this cache content is only required at image build time

plus there's a malformed gzip file in there that we want to get rid of...

https://app.shortcut.com/replicated/story/81453/rebuild-and-release-statsd-graphite-image-fix-malformed-tar-gzip-content