### PR TITLE
Fix CVEs

### DIFF
--- a/.circleci/.anchore/grype.yaml
+++ b/.circleci/.anchore/grype.yaml
@@ -1,18 +1,9 @@
 ignore:
+  - vulnerability: CVE-2023-47038
+  - vulnerability: CVE-2023-5981
 
-  # https://github.com/anchore/grype#specifying-matches-to-ignore
-  # example to ignore a vulnerability
-  # This is the full set of supported rule fields:
-  # - vulnerability: CVE-2008-4318
-  #   fix-state: unknown
-  #   package:
-  #     name: libcurl
-  #     version: 1.5.1
-  #     type: npm
-  #     location: "/usr/local/lib/node_modules/**"
+  - package:
+      type: python
 
-- package:
-    type: python
-
-- package:
-    type: npm
+  - package:
+      type: npm

--- a/conf/carbon.sh
+++ b/conf/carbon.sh
@@ -6,4 +6,4 @@
 # The --pidfile overrides the default location which is on a mounted volume, which survives container restarts.
 
 rm -f /tmp/carbon.pid
-/opt/graphite/bin/carbon-cache.py start --nodaemon --pidfile=/tmp/carbon.pid
+/usr/bin/carbon-cache start --nodaemon --pidfile=/tmp/carbon.pid --config=/opt/graphite/conf/carbon.conf

--- a/conf/graphite.ini
+++ b/conf/graphite.ini
@@ -7,3 +7,4 @@ module = wsgi:application
 disable-logging = true
 log-4xx = true
 log-5xx = true
+plugins = python3

--- a/conf/graphite/carbon.conf
+++ b/conf/graphite/carbon.conf
@@ -14,12 +14,16 @@
 # To change other directory paths, add settings to this file. The following
 # configuration variables are available with these default values:
 #
-#   STORAGE_DIR    = $GRAPHITE_STORAGE_DIR
-#   LOCAL_DATA_DIR = %(STORAGE_DIR)s/whisper/
-#   WHITELISTS_DIR = %(STORAGE_DIR)s/lists/
-#   CONF_DIR       = %(STORAGE_DIR)s/conf/
-#   LOG_DIR        = %(STORAGE_DIR)s/log/
-#   PID_DIR        = %(STORAGE_DIR)s/
+
+GRAPHITE_ROOT        = /opt/graphite
+GRAPHITE_STORAGE_DIR = %(GRAPHITE_ROOT)s/storage
+
+STORAGE_DIR    = %(GRAPHITE_ROOT)s/storage/
+LOCAL_DATA_DIR = %(STORAGE_DIR)s/whisper/
+WHITELISTS_DIR = %(STORAGE_DIR)s/lists/
+CONF_DIR       = %(GRAPHITE_ROOT)s/conf/
+LOG_DIR        = %(STORAGE_DIR)s/log/
+PID_DIR        = %(STORAGE_DIR)s/
 #
 # For FHS style directory structures, use:
 #
@@ -311,6 +315,8 @@ GRAPHITE_URL = http://127.0.0.1:38080
 # Tag update interval, this specifies how frequently updates to existing series will trigger
 # an update to the tag index, the default setting is once every 100 updates
 # TAG_UPDATE_INTERVAL = 100
+
+ENABLE_TAGS = False
 
 # To configure special settings for the carbon-cache instance 'b', uncomment this:
 #[cache:b]

--- a/conf/local_settings.py
+++ b/conf/local_settings.py
@@ -1,2 +1,4 @@
 SECRET_KEY = '$(date +%s | sha256sum | base64 | head -c 64)'
 ALLOWED_HOSTS = ['*']
+GRAPHITE_ROOT = '/opt/graphite'
+LOG_DIR = '/opt/graphite/storage/log/webapp'

--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -18,7 +18,7 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 [program:uwsgi]
-command     = /usr/local/bin/uwsgi --ini /etc/uwsgi/apps-enabled/conf/graphite.ini --pidfile /var/run/uwsgi/uwsgi.pid
+command     = /usr/bin/uwsgi --ini /etc/uwsgi/apps-enabled/conf/graphite.ini --pidfile /var/run/uwsgi/uwsgi.pid
 startsecs	= 0
 autorestart = true
 stdout_logfile=/dev/stdout

--- a/conf/wsgi.py
+++ b/conf/wsgi.py
@@ -1,0 +1,7 @@
+import sys
+# In case of multi-instance graphite, uncomment and set appropriate name
+# import os
+# os.environ['GRAPHITE_SETTINGS_MODULE'] = 'graphite.local_settings'
+sys.path.append('/usr/lib/python3/dist-packages')
+
+from graphite.wsgi import application


### PR DESCRIPTION
- Move to Debian Bookworm to resolve CVEs
- Two CVEs not yet available in the base image added to ignore list
- Graphite/StatsD image rebuilt from scratch using Debian packages for most components rather than building components from source.  The install is now in a different location and required configuration changes to adjust.

New image tested with previous Replicated release:

<img width="1188" alt="Screen Shot 2023-12-14 at 8 52 09 AM" src="https://github.com/replicatedcom/statsd-graphite/assets/1004892/f25a7f72-b256-43e1-ae73-022d4b423061">
